### PR TITLE
fix 永続ログイン設定時に初回アクセスするとエラーが発生するバグの修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@ class User < ApplicationRecord
 
   def remember_me
     self.remember = SecureRandom.urlsafe_base64
+    save
   end
 
   def forget_me


### PR DESCRIPTION
永続ログイン設定時にsaveしていなかったため、remember_digestの値がnilだったことが原因